### PR TITLE
Iterate over all content types by default

### DIFF
--- a/redturtle/historymanager/browser/manager.py
+++ b/redturtle/historymanager/browser/manager.py
@@ -223,7 +223,15 @@ class PurgeInPathView(Manager):
         portal_type = self.request.get('portal_type', '')
         max_modified = {'query': self.get_date_limit(),
                         'range': 'max'}
-        brains = pc(path=path, portal_type=portal_type, modified=max_modified)
+                        
+        query = {
+            'path': path,
+            'modified': max_modified,
+        }
+        if portal_type:
+            query['portal_type'] = portal_type
+
+        brains = pc(**query)
         return [self.dereference(brain.getObject())[1]
                 for brain in brains]
 


### PR DESCRIPTION
Before this fix, you have to set the list of content types in portal_type parameter if you want the @@historymanager-purge-thispath view to actually find any objects.

With this fix, it will find all content types if no portal_type is given.
